### PR TITLE
Add Docker Compose configuration for Python environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+*.swp
+.env
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Default command runs an interactive Python session
+CMD ["python"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # test
 練習用
+
+## Docker Compose で Python 環境を起動する
+
+以下のコマンドで Python のインタラクティブ環境が起動します。
+
+```bash
+docker compose run --rm app
+```
+
+Python のライブラリを追加したい場合は `requirements.txt` に追記してください。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: python
+    stdin_open: true
+    tty: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Add python dependencies here


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose.yml to run Python 3.11 environment
- document how to launch the container with Docker Compose
- provide requirements.txt and .dockerignore for dependency management

## Testing
- `docker compose config` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d5a1755b88323b3fb8b1165ca0420